### PR TITLE
ajustando api version do hpa deployment

### DIFF
--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -6,7 +6,7 @@ spec:
   maxReplicas: 6
   minReplicas: 1
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: go-hpa
   targetCPUUtilizationPercentage: 15


### PR DESCRIPTION
A apiversion em scale target no manifesto do HPA deve ser igual a apiversion do Deployment.


